### PR TITLE
Fetch the PR base branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,5 @@ Add the following to your `pipeline.yml`:
 steps:
   - command: "<your-command>"
     plugins:
-      - elastic/pre-commit#v1.0.0
+      - elastic/pre-commit#v1.0.1
 ```

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -5,5 +5,6 @@ set -euo pipefail
 if [ "$BUILDKITE_PULL_REQUEST" == "false" ]; then
   pre-commit run -a
 else
+  git fetch origin "$BUILDKITE_PULL_REQUEST_BASE_BRANCH":"$BUILDKITE_PULL_REQUEST_BASE_BRANCH"
   pre-commit run --from-ref "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" --to-ref HEAD --show-diff-on-failure
 fi


### PR DESCRIPTION
This should fix the `unknown revision or path not in the working tree` errors that can happens
When we create a PR to a different branch than main:

```
An unexpected error has occurred: CalledProcessError: command: ('/usr/bin/git', 'diff', '--name-only', '--no-ext-diff', '-z', '8.12..HEAD')
return code: 128
stdout: (none)
stderr:
    fatal: ambiguous argument '8.12..HEAD': unknown revision or path not in the working tree.
    Use '--' to separate paths from revisions, like this:
    'git <command> [<revision>...] -- [<file>...]'
Check the log at /root/.cache/pre-commit/pre-commit.log
🚨 Error: The plugin pre-commit post-checkout hook exited with status 3
```

⚠️ Need to create the `v1.0.1` after PR merge and to bump the plugin version in our other pipelines that use it.