### PR TITLE
Use core-ubuntu-2204 instead of unmaintained ci-ubuntu-2204

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,4 +13,4 @@ steps:
           id: elastic/pre-commit
     agents:
       provider: "gcp"
-      image: family/ci-ubuntu-2204
+      image: family/core-ubuntu-2204


### PR DESCRIPTION
The image family `ci-ubuntu-2204` has been unmaintained for a while and has been replaced by `core-ubuntu-2204`. This PR updates them to this instead.

Related to [incident 505.](https://elastic.slack.com/archives/C078RND5G5C)